### PR TITLE
Wrap summary aria-label value in quotes

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -5,7 +5,7 @@
     {{- $image := $params.featuredImagePreview | default $params.featuredImage -}}
     {{- with $image -}}
         <div class="featured-image-preview">
-            <a href="{{ $.RelPermalink }}" aria-label={{ $.Title }}>
+            <a href="{{ $.RelPermalink }}" aria-label="{{ $.Title }}">
                 {{ $optim := slice 
                     (dict "Process" "fill 800x240 Center webp q75" "descriptor" "800w")
                     (dict "Process" "fill 1200x360 Center webp q75" "descriptor" "1200w")


### PR DESCRIPTION
## Summary
- ensure summary template wraps `aria-label` value in quotes for valid HTML

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68907c26b3488321902dfed3cdb2256b